### PR TITLE
Shuffle the order of the nodes before checking its status

### DIFF
--- a/lib/fluent/plugin/in_chef_api.rb
+++ b/lib/fluent/plugin/in_chef_api.rb
@@ -107,6 +107,15 @@ module Fluent
         nodes = connection.nodes
       end
       Engine.emit("#{@tag}.nodes", Engine.now, data.merge({"value" => nodes.count}))
+      begin
+        nodes.instance_eval do
+          if Hash === @collection
+            @collection = Hash[@collection.to_a.shuffle]
+          end
+        end
+      rescue => error
+        $log.warn("failed to shuffle nodes: #{error.class}: #{error.message}")
+      end
       nodes.each do |node|
         begin
           Engine.emit("#{@tag}.run_list", Engine.now, data.merge({"value" => node.run_list.length, "node" => node.name}))


### PR DESCRIPTION
Because Ruby's Hash behaves as order-preserving, the nodes in the latter part of the collection might not be updated if there are some API request failures during enumerating `CollectionProxy`. Just randomizing the collection before enumerating `CollectionProxy` would mitigate the issue on such scenario.

Basically I think sethvargo/chef-api#42 would be better than `instance_eval`, though.
