### PR TITLE
Allow the node to perform self-diagnosis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.swo
+*.swp


### PR DESCRIPTION
Sometime we don't want single proxy instance to monitor all other nodes in specific `chef_environment`.